### PR TITLE
Bug fixing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 netdicom2/
 config_local/
+.idea
+*.pyc
+*.log
+*.db

--- a/bin/run_service.py
+++ b/bin/run_service.py
@@ -22,5 +22,6 @@ def main():
         pass
     service.stop()
 
+
 if __name__ == '__main__':
     main()

--- a/database/models.py
+++ b/database/models.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2017 Pavel 'Blane' Tuchin
 from peewee import *
+from playhouse.sqlite_ext import SqliteExtDatabase
 
 database_proxy = Proxy()
 
@@ -10,5 +11,5 @@ class BaseModel(Model):
 
 
 def init_sqlite(filename):
-    db = SqliteDatabase(filename)
+    db = SqliteExtDatabase(filename)
     database_proxy.initialize(db)


### PR DESCRIPTION
-  Minimizing transaction size. This is resolve the database locking when hundreds of files gived to wathcer.
- If exist two or more senders, with `remove_on_send option` is `True` file will be removed before second worker try to send it.
- Check that new file is DICOM dataset before add it to queue.
